### PR TITLE
Throw an error when openssl in generatePublicKey has error text.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jed Schmidt <tr@nslator.jp> (http://jed.is)",
   "name": "crx",
   "description": "Build Google Chrome extensions with node.js",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "homepage": "https://github.com/jed/crx",
   "bin": {
     "crx": "./bin/crx.js"

--- a/src/crx.js
+++ b/src/crx.js
@@ -82,8 +82,14 @@ module.exports = new function() {
     var rsa = spawn("openssl", ["rsa", "-pubout", "-outform", "DER"])
 
     rsa.stdout.on("data", function(data) {
+      if(this.publicKey)
+        return
       this.publicKey = data
       cb && cb.call(this, null, this)
+    }.bind(this))
+    rsa.stderr.on("data", function(err) {
+      this.publicKey === undefined && cb && cb.call(this, "Failed to generate private key", null)
+      this.publicKey = new Error("Failed to generate private key")
     }.bind(this))
 
     rsa.stdin.end(this.privateKey)


### PR DESCRIPTION
Resolves jed/crx#5.
