### PR TITLE
Use proper stdin options in child_process.spawn() instead of passing a file child.stdin.end()

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -79,14 +79,14 @@ module.exports = new function() {
   }
 
   this.generatePublicKey = function(cb) {
-    var rsa = spawn("openssl", ["rsa", "-pubout", "-outform", "DER"])
+    var fd_stdin = fs.openSync(this.privateKey, 'r')
+    var rsa = spawn("openssl", ["rsa", "-pubout", "-outform", "DER"],
+      {stdio: [fd_stdin, null, null]})
 
     rsa.stdout.on("data", function(data) {
       this.publicKey = data
       cb && cb.call(this, null, this)
     }.bind(this))
-
-    rsa.stdin.end(this.privateKey)
   }
 
   this.generateSignature = function() {


### PR DESCRIPTION
Passing a file child.stdin.end() wasn't working in my case, so I decided to rewrite this code in a recommended way.
