### PR TITLE
Support long private keys in latest Chrome 32

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -149,8 +149,8 @@ module.exports = new function() {
     crx.write("Cr24" + Array(13).join("\x00"), "binary")
 
     crx[4] = 2
-    crx[8] = keyLength
-    crx[12] = sigLength
+    crx.writeUInt32LE(keyLength, 8)
+    crx.writeUInt32LE(sigLength, 12)
 
     publicKey.copy(crx, 16)
     signature.copy(crx, 16 + keyLength)


### PR DESCRIPTION
In latest Chrome 32 I'm getting long private key and signature (> 256 bytes).
It means that writing directly to buffer bytes does not work correct:

``` js
crx[8] = keyLength
crx[12] = sigLength
```

When trying to install such crx you may get `CRX_ZERO_SIGNATURE_LENGTH` or `CRX_ZERO_KEY_LENGTH` errors.

This pr fixes it via using `buffer.writeUInt32LE` method.
Hope to be merged soon.
Thanks!
