### PR TITLE
removed bufferstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   },
   "dependencies": {
     "commander": "",
-    "archiver": "0.4.x",
-    "wrench": "1.5.x",
-    "bufferstream": "0.5.x"
+    "archiver": "0.8.x",
+    "wrench": "1.5.x"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
reason:
- installation breaks on Windows systems (see [camme/webdriverjs/issues/189](https://github.com/camme/webdriverjs/issues/189)) because `bufferstream` (to be exact `buffertools`) requires python
- it is obsolete
