### PR TITLE
Fix deleting remaining ./tmp directory

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -1,5 +1,6 @@
 var fs = require("fs")
-  , join = require("path").join
+  , path = require("path")
+  , join = path.join
   , sep = require("path").sep
   , crypto = require("crypto")
   , child = require("child_process")
@@ -22,7 +23,7 @@ module.exports = new function() {
   ChromeExtension.prototype = this
 
   this.destroy = function() {
-    wrench.rmdirSyncRecursive(this.path)
+    wrench.rmdirSyncRecursive(path.dirname(this.path))
   }
 
   this.pack = function(cb) {


### PR DESCRIPTION
I noticed an empty `tmp` dir was remaining while using [grunt-crx](https://github.com/oncletom/grunt-crx), this commit should fix it.
