### PR TITLE
Event 'finished' no longer valid #18

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -122,6 +122,10 @@ module.exports = new function() {
 
     archive.finalize()
     
+    // Relates to the issue: "Event 'finished' no longer valid #18"
+    // https://github.com/jed/crx/issues/18
+    // TODO: Buffer concat could be a problem when building a big extension.
+    //       So ideally only the 'finish' callback must be used.
     archive.on('readable', function() {
       this.contents = !this.contents.length ? archive.read() : Buffer.concat([this.contents, archive.read()])
     }.bind(this))


### PR DESCRIPTION
The fix relates to the issue #18.
