### PR TITLE
Added try block to catch Chrome private keys generated in pkcs8 format.

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -142,7 +142,17 @@ ChromeExtension.prototype = {
     var privateKey = this.privateKey;
 
     return new Promise(function(resolve, reject){
-      var key = new RSA(privateKey, 'pkcs1-private-pem');
+      // Chrome generates private keys in pkcs8 format
+      // see https://www.npmjs.com/package/node-rsa
+      try {
+        var key = new RSA(privateKey, 'pkcs1-private-pem');
+      } catch (e) {
+        if (e.message === 'encoding too long') {
+          var key = new RSA(privateKey, 'pkcs8-private-pem');
+        } else {
+          throw e;
+        }
+      }
 
       resolve(key.exportKey('pkcs8-public-der'));
     });


### PR DESCRIPTION
When Chrome generates a private key, it is generated in the pkcs8 header format, i.e. 
`-----BEGIN PUBLIC KEY-----` 

as opposed to the pkcs1 format: 

`-----BEGIN RSA PUBLIC KEY-----`

this throws `InvalidAsn1Error: encoding too long` when generating a public key from a Chrome generated private key.