### PR TITLE
Do not concatenate a possible null buffer.

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -217,7 +217,11 @@ ChromeExtension.prototype = {
         // TODO: Buffer concat could be a problem when building a big extension.
         //       So ideally only the 'finish' callback must be used.
         archive.on('readable', function () {
-          contents = Buffer.concat([contents, archive.read()]);
+          var buf = archive.read();
+
+          if (buf) {
+            contents = Buffer.concat([contents, buf]);
+          }
         });
 
         archive.on('finish', function () {


### PR DESCRIPTION
It is a Node v0.12/Io.js v1.x change.

closes #38