### PR TITLE
added .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+.travis.yml


### PR DESCRIPTION
including the test/ folder to .npmignore means it will not be downloaded on npm install. This has two advantages:

1. less data to download on `npm install`
2. when developing a google chrome extension, a warning pops out, saying *This extension includes the key file '.../node_modules/crx/test/key.pem'. You probably don't want to do that.* There is no security threat since the key is not used anyway; the npmignore just gets rid of the warning.