### PR TITLE
updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "changelog": "github-changes -o oncletom -r crx -n ${npm_package_version} -a --only-pulls --use-commit-body"
   },
   "dependencies": {
-    "archiver": "^0.8.0",
+    "archiver": "0.12.0",
     "commander": "^2.5.0",
-    "es6-promise": "^2.0.0",
-    "node-rsa": "^0.2.10",
+    "es6-promise": "^3.0.2",
+    "node-rsa": "^0.3.2",
     "temp": "^0.8.1",
     "wrench": "^1.5.0"
   },
   "devDependencies": {
     "github-changes": "^1.0.0",
     "sinon": "^1.12.1",
-    "tape": "^3.0.3"
+    "tape": "^4.4.0"
   }
 }


### PR DESCRIPTION
archiver cannot be updated to newest version because node.js 0.8 tests fail (no function setImmediate).