### PR TITLE
Reject load promise if requiring the manifest fails

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -99,7 +99,12 @@ ChromeExtension.prototype = {
           return reject(err);
         }
 
-        selfie.manifest = require(join(selfie.path, "manifest.json"));
+        try {
+          selfie.manifest = require(join(selfie.path, "manifest.json"));
+        }
+        catch(ex) {
+          return reject(ex);
+        }
         selfie.loaded = true;
 
         resolve(selfie);


### PR DESCRIPTION
Avoiding this error:

module.js:338
    throw err;
    ^

Error: Cannot find module 'XXXXXXXXXXXXXXXXX/manifest.json'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at XXXXXXXXXXXX/node_modules/crx/src/crx.js:102:27
    at copyFiles (XXXXXXXXXXXX/node_modules/wrench/lib/wrench.js:434:36)
    at copyFiles (XXXXXXXXXXXX/node_modules/wrench/lib/wrench.js:434:36)
    at FSReqWrap.oncomplete (fs.js:82:15)