### PR TITLE
[security fix] Updated archiver dependency; drops support for node 0.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: node_js
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'
   - '4.1'
   - '5.0'
+  - '6'
+  - 'node'
 
 sudo: false
-
-before_install:
-  - npm install --global npm@1.4.6

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "changelog": "github-changes -o oncletom -r crx -n ${npm_package_version} -a --only-pulls --use-commit-body"
   },
   "dependencies": {
-    "archiver": "^0.8.0",
+    "archiver": "^1.1.0",
     "commander": "^2.5.0",
     "es6-promise": "^2.0.0",
     "node-rsa": "^0.2.10",


### PR DESCRIPTION
Old archiver comes with old minimatch which suffers of a known vulnerability: https://nodesecurity.io/advisories/118

Updating archiver updates minimatch as well.

Archiver no longer supports node.js 0.8.x which means crx does not support it either. I guess this deserves a major version bump.
