### PR TITLE
Drop iojs from package.engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "main": "./src/crx.js",
   "engines": {
-    "node": ">=0.10",
-    "iojs": ">=1.0.0 <2.0.0"
+    "node": ">=0.10"
   },
   "scripts": {
     "test": "nyc tape ./test/*.js",


### PR DESCRIPTION
Current `engines` option makes `crx` [incompatible with modern versions of node](https://github.com/yarnpkg/yarn/issues/623#issuecomment-253117126).

This PR fixes the issue by removing `iojs` field altogether. It's kind of unnecessary anyway since iojs has been merged into node itself 😏

Please correct me if i'm wrong, we'll find a way around it. Thanks!