### PR TITLE
Remove the manifest data from cache on crx.load()

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -92,8 +92,11 @@ ChromeExtension.prototype = {
       .then(function(metadata){
         selfie.path = metadata.path;
         selfie.src = metadata.src;
+	    
+        var manifestPath = join(selfie.path, 'manifest.json')
+        delete require.cache[manifestPath];
 
-        selfie.manifest = require(join(selfie.path, "manifest.json"));
+        selfie.manifest = require(manifestPath);
         selfie.loaded = true;
 
         return selfie;


### PR DESCRIPTION
The require API keeps a global cache of all the files loaded via require(). Changes in the 'manifest.json' will not be picked up after the first time crx.load(...) is run.