### PR TITLE
feat: use `manifest.minimum_chrome_version` as XML's `prodversionmin`

### DIFF
--- a/src/crx.js
+++ b/src/crx.js
@@ -260,7 +260,7 @@ class ChromeExtension {
    *
    * If manifest does not include `minimum_chrome_version`, defaults to:
    * - '29.0.0' for CRX2, which is earliest extensions API available
-   * - '70.0.0' for CRX3, which is around one year after Chromium switched to generating CRX3 packages
+   * - '64.0.3242' for CRX3, which is when Chrome etension packager switched to CRX3
    *
    * BC BREAK `this.updateXML` is not stored anymore (since 1.0.0)
    *
@@ -279,7 +279,7 @@ class ChromeExtension {
 
     var browserVersion = this.manifest.minimum_chrome_version
       || (this.version < 3 && "29.0.0") // Earliest version with extensions API
-      || "70.0.0"; // Around one year after Chromium started generating CRX3 packages
+      || "64.0.3242"; // Chrome started generating CRX3 packages
 
     return Buffer.from(`<?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>

--- a/src/crx.js
+++ b/src/crx.js
@@ -258,8 +258,18 @@ class ChromeExtension {
   /**
    * Generates an updateXML file from the extension content.
    *
+   * If manifest does not include `minimum_chrome_version`, defaults to:
+   * - '29.0.0' for CRX2, which is earliest extensions API available
+   * - '70.0.0' for CRX3, which is around one year after Chromium switched to generating CRX3 packages
+   *
    * BC BREAK `this.updateXML` is not stored anymore (since 1.0.0)
    *
+   * @see
+   *   [Chrome Extensions APIs]{@link https://developer.chrome.com/extensions/api_index}
+   * @see
+   *   [Chrome verions]{@link https://en.wikipedia.org/wiki/Google_Chrome_version_history}
+   * @see
+   *   [Chromium switches to CRX3]{@link https://chromium.googlesource.com/chromium/src.git/+/b8bc9f99ef4ad6223dfdcafd924051561c05ac75}
    * @returns {Buffer}
    */
   generateUpdateXML () {
@@ -268,7 +278,7 @@ class ChromeExtension {
     }
 
     var browserVersion = this.manifest.minimum_chrome_version
-      || (this.version < 3 && "29.0.0") // Earliest API available: https://developer.chrome.com/extensions/api_index
+      || (this.version < 3 && "29.0.0") // Earliest version with extensions API
       || "70.0.0"; // Around one year after Chromium started generating CRX3 packages
 
     return Buffer.from(`<?xml version='1.0' encoding='UTF-8'?>

--- a/src/crx.js
+++ b/src/crx.js
@@ -267,10 +267,14 @@ class ChromeExtension {
       throw new Error("No URL provided for update.xml.");
     }
 
+    var browserVersion = this.manifest.minimum_chrome_version
+      || (this.version < 3 && "29.0.0") // Earliest API available: https://developer.chrome.com/extensions/api_index
+      || "70.0.0"; // Around one year after Chromium started generating CRX3 packages
+
     return Buffer.from(`<?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='${this.appId || this.generateAppId()}'>
-    <updatecheck codebase='${this.codebase}' version='${this.manifest.version}' />
+    <updatecheck codebase='${this.codebase}' version='${this.manifest.version}' prodversionmin='${browserVersion}' />
   </app>
 </gupdate>`);
   }

--- a/test/expectations/updateCRX2.xml
+++ b/test/expectations/updateCRX2.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='eoilidhiokfphdhpmhoaengdkehanjif'>
+    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' prodversionmin='29.0.0' />
+  </app>
+</gupdate>

--- a/test/expectations/updateCRX3.xml
+++ b/test/expectations/updateCRX3.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='eoilidhiokfphdhpmhoaengdkehanjif'>
-    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' />
+    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' prodversionmin='70.0.0' />
   </app>
 </gupdate>

--- a/test/expectations/updateCRX3.xml
+++ b/test/expectations/updateCRX3.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
   <app appid='eoilidhiokfphdhpmhoaengdkehanjif'>
-    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' prodversionmin='70.0.0' />
+    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' prodversionmin='64.0.3242' />
   </app>
 </gupdate>

--- a/test/expectations/updateProdVersionMin.xml
+++ b/test/expectations/updateProdVersionMin.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='eoilidhiokfphdhpmhoaengdkehanjif'>
+    <updatecheck codebase='http://localhost:8000/myFirstExtension.crx' version='1.0' prodversionmin='99.99.99-crxtest' />
+  </app>
+</gupdate>


### PR DESCRIPTION
Default to '29.0.0' for CRX2 and '70.0.0' for CRX3.

Fixes: #13 