### PR TITLE
readme: change writeFile to writeFileSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ crx.load( path.resolve(__dirname, './myExtension') )
   .then(crxBuffer => {
     const updateXML = crx.generateUpdateXML()
 
-    fs.writeFile('../update.xml', updateXML);
-    fs.writeFile('../myExtension.crx', crxBuffer);
+    fs.writeFileSync('../update.xml', updateXML);
+    fs.writeFileSync('../myExtension.crx', crxBuffer);
   })
   .catch(err=>{
     console.error( err );
@@ -77,7 +77,7 @@ Packs the Chrome Extension and resolves the promise with a Buffer containing the
 crx.load('/path/to/extension')
   .then(crx => crx.pack())
   .then(crxBuffer => {
-    fs.writeFile('/tmp/foobar.crx', crxBuffer);
+    fs.writeFileSync('/tmp/foobar.crx', crxBuffer);
   });
 ```
 
@@ -93,7 +93,7 @@ crx.load('/path/to/extension')
   .then(crxBuffer => {
     // ...
     const xmlBuffer = crx.generateUpdateXML();
-    fs.writeFile('/foo/bar/update.xml', xmlBuffer);
+    fs.writeFileSync('/foo/bar/update.xml', xmlBuffer);
   });
 ```
 


### PR DESCRIPTION
according to the [nodejs docs](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback), `writeFile` needs a callback, and the example in the readme won't work. I changed it to `writeFileSync` in order to show working examples.